### PR TITLE
feat: add my page sidebar layout

### DIFF
--- a/src/features/members/components/MyPageProfileSection.tsx
+++ b/src/features/members/components/MyPageProfileSection.tsx
@@ -1,0 +1,76 @@
+import { Button } from '@/components/ui/button';
+import CheckWithdrawDialog from '@/features/members/components/CheckWithdrawDialog';
+import ProfileImageField from '@/features/members/components/ProfileImageField';
+import ProfileNickNameField from '@/features/members/components/ProfileNicknameField';
+import ProfilePasswdField from '@/features/members/components/ProfilePasswdField';
+import WithdrawalSuccessDialog from '@/features/members/components/WithdrawalSuccessDialog';
+import type { Member } from '@/features/members/types/types';
+
+export type MyPageProfileSectionProps = {
+  member: Member;
+  updateMember: (member: Member) => void;
+  isCheckWithdrawDialogOpen: boolean;
+  setCheckWithdrawDialog: () => void;
+  deleteAccount: () => void;
+  isWithdrawSuccessDialogOpen: boolean;
+  setWithdrawSuccessDialog: () => void;
+  onAccountDeleted: () => void;
+};
+
+export default function MyPageProfileSection({
+  member,
+  updateMember,
+  isCheckWithdrawDialogOpen,
+  setCheckWithdrawDialog,
+  deleteAccount,
+  isWithdrawSuccessDialogOpen,
+  setWithdrawSuccessDialog,
+  onAccountDeleted,
+}: MyPageProfileSectionProps) {
+  return (
+    <section className='rounded-2xl border-2 border-yellow-400 bg-white p-6 shadow-sm md:p-8'>
+      <h1 className='text-xl font-semibold'>내 프로필</h1>
+
+      <div className='mt-6 space-y-6'>
+        <ProfileImageField
+          imgUrl={member.imageUrl}
+          updateMember={updateMember}
+        />
+
+        <ProfileNickNameField
+          nickname={member.nickname}
+          updateMember={updateMember}
+        />
+
+        <div className='flex items-center'>
+          <div className='w-28 font-semibold'>이메일: </div>
+          <div className='flex w-full items-center justify-between'>
+            <span className='font-bold underline'>{member.email} </span>
+          </div>
+        </div>
+
+        <ProfilePasswdField updateMember={updateMember} />
+      </div>
+      <div className='mt-20 mr-2 flex justify-end'>
+        <Button
+          variant={'outline_semibold'}
+          onClick={setCheckWithdrawDialog}
+          className='text-red-500 hover:text-red-500'
+        >
+          회원 탈퇴
+        </Button>
+      </div>
+      <CheckWithdrawDialog
+        isOpen={isCheckWithdrawDialogOpen}
+        setCheckWithdrawDialog={setCheckWithdrawDialog}
+        deleteAccount={deleteAccount}
+      />
+
+      <WithdrawalSuccessDialog
+        isOpen={isWithdrawSuccessDialogOpen}
+        setWithdrawSuccessDialog={setWithdrawSuccessDialog}
+        onAccountDeleted={onAccountDeleted}
+      />
+    </section>
+  );
+}

--- a/src/features/members/components/MyPageSidebar.tsx
+++ b/src/features/members/components/MyPageSidebar.tsx
@@ -1,0 +1,41 @@
+import { cn } from '@/lib/utils';
+import {
+  BarChart3,
+  Bookmark,
+  MessageSquareText,
+  UserRound,
+  HelpCircle,
+} from 'lucide-react';
+
+const MENU_ITEMS = [
+  { label: '학습 성취도', icon: BarChart3 },
+  { label: '스크랩', icon: Bookmark },
+  { label: '내 리뷰', icon: MessageSquareText },
+  { label: '프로필', icon: UserRound, active: true },
+  { label: '퀴즈', icon: HelpCircle },
+];
+
+export default function MyPageSidebar() {
+  return (
+    <aside className='hidden h-fit rounded-2xl border bg-white p-6 shadow-sm md:block'>
+      <nav aria-label='마이페이지 메뉴' className='space-y-4'>
+        {MENU_ITEMS.map((item) => {
+          const Icon = item.icon;
+          return (
+            <div
+              key={item.label}
+              className={cn(
+                'flex items-center gap-3 rounded-xl px-3 py-2 text-sm font-medium text-gray-500 transition-colors hover:text-gray-900',
+                item.active && 'bg-yellow-100 text-gray-900'
+              )}
+              aria-current={item.active ? 'page' : undefined}
+            >
+              <Icon className='h-5 w-5' />
+              <span>{item.label}</span>
+            </div>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+}

--- a/src/pages/MyPage.tsx
+++ b/src/pages/MyPage.tsx
@@ -1,10 +1,6 @@
-import { Button } from '@/components/ui/button';
+import MyPageProfileSection from '@/features/members/components/MyPageProfileSection';
+import MyPageSidebar from '@/features/members/components/MyPageSidebar';
 import { useSession } from '@/features/auth/context/useSession';
-import CheckWithdrawDialog from '@/features/members/components/CheckWithdrawDialog';
-import ProfileImageField from '@/features/members/components/ProfileImageField';
-import ProfileNickNameField from '@/features/members/components/ProfileNicknameField';
-import ProfilePasswdField from '@/features/members/components/ProfilePasswdField';
-import WithdrawalSuccessDialog from '@/features/members/components/WithdrawalSuccessDialog';
 import { useDeleteMemberMutation } from '@/hooks/useDeleteMemberMutation';
 import { useReducer } from 'react';
 
@@ -32,51 +28,22 @@ export default function MyPage() {
 
   return (
     <div className='min-h-screen bg-white p-6'>
-      <div className='max-w-3xl mx-auto'>
-        <section className='bg-white border-2 border-yellow-400 rounded-2xl shadow-sm p-6 md:p-8'>
-          <h1 className='font-semibold text-xl'>내 프로필</h1>
-
-          <div className='mt-6 space-y-6'>
-            <ProfileImageField
-              imgUrl={member.imageUrl}
-              updateMember={updateMember}
-            />
-
-            <ProfileNickNameField
-              nickname={member.nickname}
-              updateMember={updateMember}
-            />
-
-            <div className='flex items-center'>
-              <div className='w-28 font-semibold'>이메일: </div>
-              <div className='flex w-full justify-between items-center'>
-                <span className='font-bold underline'>{member.email} </span>
-              </div>
-            </div>
-
-            <ProfilePasswdField updateMember={updateMember} />
-          </div>
-          <div className='flex justify-end mr-2 mt-20'>
-            <Button
-              variant={'outline_semibold'}
-              onClick={setCheckWithdrawDialog}
-              className='text-red-500 hover:text-red-500'
-            >
-              회원 탈퇴
-            </Button>
-          </div>
-          <CheckWithdrawDialog
-            isOpen={isCheckWithdrawDialogOpen}
+      <div className='mx-auto grid max-w-5xl grid-cols-1 gap-6 md:grid-cols-4'>
+        <div className='md:col-span-1'>
+          <MyPageSidebar />
+        </div>
+        <div className='md:col-span-3'>
+          <MyPageProfileSection
+            member={member}
+            updateMember={updateMember}
+            isCheckWithdrawDialogOpen={isCheckWithdrawDialogOpen}
             setCheckWithdrawDialog={setCheckWithdrawDialog}
             deleteAccount={deleteAccount}
-          />
-
-          <WithdrawalSuccessDialog
-            isOpen={isWithdrawSuccessDialogOpen}
+            isWithdrawSuccessDialogOpen={isWithdrawSuccessDialogOpen}
             setWithdrawSuccessDialog={setWithdrawSuccessDialog}
             onAccountDeleted={onAccountDeleted}
           />
-        </section>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- extract the existing profile section into a dedicated MyPageProfileSection component
- create a sidebar component with placeholder navigation items for the MyPage layout
- update MyPage to use the new components in a 1:3 grid layout

## Testing
- yarn lint *(fails: missing eslint-plugin-storybook dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8bab4bb08832da8afaf08ab4817db